### PR TITLE
🎉 Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.6.0](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.0) - 2023-09-06
+
+### ❤️ Thanks to all contributors! ❤️
+
+@anbraten, @Anbraten
+
+### ✨ Features
+
+- feat: add release config [[#5](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/5)]
+
+### Misc
+
+- feat: add releaser-helper ([ab03ee2](https://github.com/woodpecker-ci/plugin-ready-release-go/commit/ab03ee22ed0711019157ebbeb58737ca8e2882cd))
+- feat: allow to disable comments on released PRs ([2531aa8](https://github.com/woodpecker-ci/plugin-ready-release-go/commit/2531aa8057e9cc935c90a3d9e1070001bc114899))


### PR DESCRIPTION
## [0.6.0](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.0) - 2023-09-06

### ✨ Features

- feat: add release config [[#5](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/5)]

### Misc

- feat: add releaser-helper ([ab03ee2](https://github.com/woodpecker-ci/plugin-ready-release-go/commit/ab03ee22ed0711019157ebbeb58737ca8e2882cd))
- feat: allow to disable comments on released PRs ([2531aa8](https://github.com/woodpecker-ci/plugin-ready-release-go/commit/2531aa8057e9cc935c90a3d9e1070001bc114899))