### PR TITLE
Fix backports added in changelogs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ async function run() {
       ? [releaseBranch] // use all commits of release branch if first release
       : {
           from: lastestTag,
+          symmetric: false,
           to: releaseBranch,
         }
   );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -64,7 +64,7 @@ export const defaultUserConfig: UserConfig = {
       default: true,
     },
   ],
-  skipLabels: ["skip-release", "skip-changelog"],
+  skipLabels: ["skip-release", "skip-changelog", "regression"],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: true,
 };


### PR DESCRIPTION
Closes #8 
Closes #9 

You need to use two-dot comparison to not include backport commits in the comparison log