### PR TITLE
🎉 Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-25
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-26
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- chore(deps): update dependency @types/node to v20 [[#15](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/15)]
 - chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v2.2.0 [[#29](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/29)]
 - fix(deps): update dependency @octokit/rest to v20 [[#17](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/17)]
 - fix(deps): update dependency execa to v8 [[#18](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/18)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-06
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-11
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- fix(deps): update dependency @octokit/rest to v20 [[#17](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/17)]
 - fix(deps): update dependency execa to v8 [[#18](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/18)]
 - Add renovate config [[#12](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/12)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- chore(deps): lock file maintenance [[#26](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/26)]
 - chore(deps): update vitest monorepo to ^0.34.0 [[#14](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/14)]
 - chore(deps): update dependency @types/node to v20 [[#15](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/15)]
 - chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v2.2.0 [[#29](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/29)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-27
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-28
 
 ### ❤️ Thanks to all contributors! ❤️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-02
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-06
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@pat-s
+@renovate[bot], @pat-s
 
 ### Misc
 
+- fix(deps): update dependency execa to v8 [[#18](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/18)]
 - Add renovate config [[#12](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/12)]
 
 ## [0.6.1](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.1) - 2023-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-02
+
+### ❤️ Thanks to all contributors! ❤️
+
+@pat-s
+
+### Misc
+
+- Add renovate config [[#12](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/12)]
+
 ## [0.6.1](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.1) - 2023-09-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-26
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-27
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- chore(deps): update vitest monorepo to ^0.34.0 [[#14](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/14)]
 - chore(deps): update dependency @types/node to v20 [[#15](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/15)]
 - chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v2.2.0 [[#29](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/29)]
 - fix(deps): update dependency @octokit/rest to v20 [[#17](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/17)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-28
+## [0.7.0](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.7.0) - 2023-10-31
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@renovate[bot], @pat-s
+@anbraten, @renovate[bot], @pat-s
+
+### 📈 Enhancement
+
+- Add note to release PR about this plugin [[#36](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/36)]
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-11
+## [0.6.2](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.6.2) - 2023-10-25
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v2.2.0 [[#29](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/29)]
 - fix(deps): update dependency @octokit/rest to v20 [[#17](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/17)]
 - fix(deps): update dependency execa to v8 [[#18](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/18)]
 - Add renovate config [[#12](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/12)]


### PR DESCRIPTION
## [0.7.0](https://github.com/woodpecker-ci/plugin-ready-release-go/releases/tag/0.7.0) - 2023-10-31

### 📈 Enhancement

- Add note to release PR about this plugin [[#36](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/36)]

### Misc

- chore(deps): lock file maintenance [[#26](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/26)]
- chore(deps): update vitest monorepo to ^0.34.0 [[#14](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/14)]
- chore(deps): update dependency @types/node to v20 [[#15](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/15)]
- chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v2.2.0 [[#29](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/29)]
- fix(deps): update dependency @octokit/rest to v20 [[#17](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/17)]
- fix(deps): update dependency execa to v8 [[#18](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/18)]
- Add renovate config [[#12](https://github.com/woodpecker-ci/plugin-ready-release-go/pull/12)]