### PR TITLE
Add `customReleaseBody` var and allow configuring `includeContributors`

### DIFF
--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -64,6 +64,7 @@ const config: Config = {
     githubToken: "123",
     isCI: true,
     releasePrefix: "🎉 Release",
+    customReleaseBody: "### ❤️ Thanks to all contributors! ❤️"
   },
   user: defaultUserConfig,
 };

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -111,8 +111,10 @@ export function getChangeLogSection(
 
   let section = `## [${nextVersion}](${releaseLink}) - ${releaseDate}\n\n`;
 
-  if (includeContributors) {
+  if (config.user.includeContributors) {
     section += `${contributors}\n\n`;
+  } else {
+    section += `${config.ci.customReleaseBody}\n\n`;
   }
 
   section += `${changeLog}`;

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -102,7 +102,7 @@ export function getChangeLogSection(
     nextVersion
   );
 
-  const contributors = `### ❤️ Thanks to all contributors! ❤️\n\n${changes
+  const contributors = `${config.ci.customReleaseBody}\n\n${changes
     .map((change) => `@${change.author}`)
     .filter((v, i, a) => a.indexOf(v) === i)
     .join(", ")}`;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -68,6 +68,7 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ["skip-release", "skip-changelog", "regression"],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: true,
+  includeContributors: true
 };
 
 export async function getConfig(): Promise<Config> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,6 +18,7 @@ const ciConfig = {
   repoOwner: process.env.PLUGIN_REPO_OWNER || process.env.CI_REPO_OWNER,
   repoName: process.env.PLUGIN_REPO_NAME || process.env.CI_REPO_NAME,
   releasePrefix: "🎉 Release",
+  customReleaseBody: "### ❤️ Thanks to all contributors! ❤️"
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,8 +17,8 @@ const ciConfig = {
   gitEmail: process.env.PLUGIN_GIT_EMAIL,
   repoOwner: process.env.PLUGIN_REPO_OWNER || process.env.CI_REPO_OWNER,
   repoName: process.env.PLUGIN_REPO_NAME || process.env.CI_REPO_NAME,
-  releasePrefix: "🎉 Release",
-  customReleaseBody: "### ❤️ Thanks to all contributors! ❤️"
+  releasePrefix: process.env.RELEASE_PREFIX || "🎉 Release",
+  customReleaseBody: process.env.CUSTOM_RELEASE_BODY || "### ❤️ Thanks to all contributors! ❤️"
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -112,6 +112,12 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
+
+  /**
+   * Whether to include contributors in the release notes
+   * @default true
+   */
+  includeContributors: boolean;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;


### PR DESCRIPTION
fix #23

- Add support for providing a custom release body via `customReleaseBody`
- Add support for configuring `includeContributors`
- Conditions the use of `customReleaseBody` on `includeContributors: true/false`


Disclaimer: I don't really know what should go into `config.user` and what into `config.ci` - let me know if things should be structured differently.