### PR TITLE
Add nix flake for dev environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1714725495,
+        "narHash": "sha256-BXz9MCdzNeJwhkmbl7/8twsSN8I7wy/Weu9X7WYIu2Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "754784d9f9495a183dd8f0ed8065e4b6eb909f24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -13,17 +13,18 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714725495,
-        "narHash": "sha256-BXz9MCdzNeJwhkmbl7/8twsSN8I7wy/Weu9X7WYIu2Q=",
+        "lastModified": 1715614915,
+        "narHash": "sha256-O6sqpppOtlfgx6PK5bnkAvBudK1rpjP7ig0dj7HvIl0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "754784d9f9495a183dd8f0ed8065e4b6eb909f24",
+        "rev": "d2ed14aa4f912254c578fc19b842f2910c9146be",
         "type": "github"
       },
       "original": {
@@ -36,26 +37,10 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,13 @@
 {
   # Override nixpkgs to use the latest set of node packages
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
-  inputs.systems.url = "github:nix-systems/default";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-      systems,
-    }:
-    flake-utils.lib.eachSystem (import systems) (
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  # Override nixpkgs to use the latest set of node packages
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+  inputs.systems.url = "github:nix-systems/default";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      systems,
+    }:
+    flake-utils.lib.eachSystem (import systems) (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            onefetch
+
+            nodejs
+            nodejs.pkgs.pnpm
+
+            nodePackages.typescript
+            nodePackages.typescript-language-server
+          ];
+          shellHook = ''
+            onefetch
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
             nodePackages.typescript-language-server
           ];
           shellHook = ''
-            onefetch
+            onefetch --number-of-authors 5
           '';
         };
       }


### PR DESCRIPTION
if you have `nix` package manager installed or are on nixos and have flake feature enabled, just use:

```sh
nix develop -c $SHELL
```

to have nodejs, pnpm and typescript installed in the current shell environment. system packages are temporary overwritten in that shell.