### PR TITLE
Add "dependency" to default changeTypes

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -61,6 +61,12 @@ export const defaultUserConfig: UserConfig = {
       bump: 'patch',
       default: true,
     },
+    {
+      title: '⚙️ Dependency',
+      labels: ['dependency', 'dependencies'],
+      bump: 'patch',
+      default: true,
+    },
   ],
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,


### PR DESCRIPTION
Useful to group PRs by automation bots like renovate.