### PR TITLE
Add `ci skip` suffix to PR commits

### DIFF
--- a/src/cmd/prepare.ts
+++ b/src/cmd/prepare.ts
@@ -77,7 +77,7 @@ export async function prepare(cmdCtx: CommandContext) {
   const { isClean } = await git.status();
   if (!isClean()) {
     await git.add('.');
-    await git.commit(`${config.ci.releasePrefix} ${nextVersion}`);
+    await git.commit(`${config.ci.releasePrefix} ${nextVersion} ${config.ci.skipCi}`);
     await git.push(['-u', 'origin', pullRequestBranch]);
   }
 

--- a/src/cmd/prepare.ts
+++ b/src/cmd/prepare.ts
@@ -77,7 +77,7 @@ export async function prepare(cmdCtx: CommandContext) {
   const { isClean } = await git.status();
   if (!isClean()) {
     await git.add('.');
-    await git.commit(`${config.ci.releasePrefix} ${nextVersion} ${config.ci.skipCi}`);
+    await git.commit(`${config.ci.releasePrefix} ${nextVersion} ${config.user.skipCi}`);
     await git.push(['-u', 'origin', pullRequestBranch]);
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,7 +17,6 @@ const ciConfig = {
   pullRequestBranchPrefix: process.env.PLUGIN_PULL_REQUEST_BRANCH_PREFIX || 'next-release/',
   releasePrefix: '🎉 Release',
   debug: process.env.PLUGIN_DEBUG === 'true',
-  skipCi: '[ci skip]',
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };
@@ -74,6 +73,7 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: true,
+  skipCi: '[ci skip]',
 };
 
 export async function getConfig(): Promise<Config> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,7 @@ const ciConfig = {
   pullRequestBranchPrefix: process.env.PLUGIN_PULL_REQUEST_BRANCH_PREFIX || 'next-release/',
   releasePrefix: '🎉 Release',
   debug: process.env.PLUGIN_DEBUG === 'true',
+  skipCi: '[ci skip]',
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -108,6 +108,11 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
+  /**
+   * PR commit suffix
+   * @default '[ci skip]'
+   */
+  skipCi: string;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;


### PR DESCRIPTION
There is no scenario of which I can think that one would want a CI run for the PR containing the upcoming changelog.

Instead, it often triggers other pipelines that run on the `pull_request` trigger without any need.