### PR TITLE
Allow customization of `releasePrefix`

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -54,6 +54,7 @@ There are two parts to configure the plugin:
 | `RELEASE_BRANCH`             | CI_REPO_DEFAULT_BRANCH | The branch used to merge the changelog to         |
 | `PULL_REQUEST_BRANCH_PREFIX` | `next-release/`        | The prefix used for release pull-request branches |
 | `DEBUG`                      | `false`                | Enable debug logging                              |
+| `RELEASE_PREFIX`             | 🎉 Release             | Prefix of the PR title                            |
 
 ### 2. Using a `release-config.ts` file in your repository
 

--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -75,7 +75,7 @@ const config: Config = {
     pullRequestBranchPrefix: 'next-release/',
     isCI: true,
     debug: false,
-    releasePrefix: '🎉 Release'
+    releasePrefix: '🎉 Release',
   },
   user: defaultUserConfig,
 };

--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -74,8 +74,8 @@ const config: Config = {
     forgeURL: '',
     pullRequestBranchPrefix: 'next-release/',
     isCI: true,
-    releasePrefix: '🎉 Release',
     debug: false,
+    releasePrefix: '🎉 Release'
   },
   user: defaultUserConfig,
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,6 +16,7 @@ const ciConfig = {
   repoName: process.env.CI_REPO_NAME,
   pullRequestBranchPrefix: process.env.PLUGIN_PULL_REQUEST_BRANCH_PREFIX || 'next-release/',
   debug: process.env.PLUGIN_DEBUG === 'true',
+  releasePrefix: process.env.PLUGIN_RELEASE_PREFIX || '🎉 Release',
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };
@@ -71,8 +72,7 @@ export const defaultUserConfig: UserConfig = {
   ],
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
-  commentOnReleasedPullRequests: true,
-  releasePrefix: '🎉 Release',
+  commentOnReleasedPullRequests: true
 };
 
 export async function getConfig(): Promise<Config> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -72,7 +72,7 @@ export const defaultUserConfig: UserConfig = {
   ],
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
-  commentOnReleasedPullRequests: true
+  commentOnReleasedPullRequests: true,
 };
 
 export async function getConfig(): Promise<Config> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,7 +15,6 @@ const ciConfig = {
   repoOwner: process.env.CI_REPO_OWNER,
   repoName: process.env.CI_REPO_NAME,
   pullRequestBranchPrefix: process.env.PLUGIN_PULL_REQUEST_BRANCH_PREFIX || 'next-release/',
-  releasePrefix: '🎉 Release',
   debug: process.env.PLUGIN_DEBUG === 'true',
 };
 
@@ -73,6 +72,7 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: true,
+  releasePrefix: '🎉 Release',
 };
 
 export async function getConfig(): Promise<Config> {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -108,6 +108,12 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
+
+  /**
+   * Prefix for the PR title
+   * @default '🎉 Release'
+   */
+  releasePrefix: string;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -109,11 +109,6 @@ export type UserConfig = Partial<{
    */
   commentOnReleasedPullRequests: boolean;
 
-  /**
-   * Prefix for the PR title
-   * @default '🎉 Release'
-   */
-  releasePrefix: string;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -108,7 +108,6 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
-
 }>;
 
 export const defineConfig = (config: UserConfig) => config;


### PR DESCRIPTION
~~Currently it is hard-coded and no env var is assigned, so it can't be altered (if I'm correct).
Moving it to the user config section should make this possible.~~

EDIT: keeping in `config.ci` due to internal semantics but assigning a default env var (which makes it configurable) seems a better way.

fix #22