### PR TITLE
Split Dockerfile into two stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-FROM node:22-slim
-
+FROM --platform=$BUILDPLATFORM node:22-slim AS build
 WORKDIR /app
-
 ENV NODE_ENV=production
+
+COPY ["package.json", "pnpm-lock.yaml", "./"]
+
+RUN corepack enable
+RUN pnpm install --frozen-lockfile --package-import-method copy
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build "/app/node_modules" "./node_modules"
+COPY "tsconfig.json" "./tsconfig.json"
+COPY "src" "./src"
 
 RUN apt update \
 	&& apt install -y git git-lfs wget \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-RUN corepack enable
-
-COPY ["package.json", "pnpm-lock.yaml", "./"]
-RUN pnpm install --frozen-lockfile
-
-COPY ["tsconfig.json", "./"]
-COPY ["src", "./src"]
 
 CMD ["/app/node_modules/.bin/tsx", "/app/src/run.ts"]


### PR DESCRIPTION
to run `pnpm install` only once and as much as possible native not emulated

ref: https://ci.woodpecker-ci.org/repos/8986/pipeline/424/4