### PR TITLE
Refactor `gitea.ts`

### DIFF
--- a/src/forges/gitea.ts
+++ b/src/forges/gitea.ts
@@ -55,7 +55,6 @@ export class GiteaForge extends Forge {
         prList.base?.ref === options.targetBranch &&
         prList.head?.ref === options.sourceBranch &&
         prList.state === 'open' &&
-        prList.title === options.title,
     );
 
     let pullRequest = filteredPullRequests?.[0];


### PR DESCRIPTION
fix #192 

- List all PRs and filter accordingly instead of using `headBase` Ref endpoint (broken as it only returns one (the first match)
- Include API response in general error catching fun
- Wrap all funs with `handleApiErrors()`

Proven to work: 

- [PR created](https://ci.codeberg.org/repos/13893/pipeline/86/3)
- [PR updated](https://ci.codeberg.org/repos/13893/pipeline/87/3)

This failed beforehand, specifically the second part of updating an open PR as the open PR was not found when another closed one already existed.

Using `repoGetPullRequestByBaseHead()` is preferred as it does somewhat of a shortcut in terms of filtering. But it must be fixed upstream.