### PR TITLE
adds default changeTypes in  readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,50 @@ To change it, create a `release-config.ts` at the repository root and overwrite 
 export default {
   changeTypes: [
     {
-      // CUSTOM LABEL CONFIG HERE
+      title: '💥 Breaking changes',
+      labels: ['breaking'],
+      bump: 'major',
+      weight: 3,
+    },
+    {
+      title: '🔒 Security',
+      labels: ['security'],
+      bump: 'patch',
+      weight: 2,
+    },
+    {
+      title: '✨ Features',
+      labels: ['feature', 'feature 🚀️'],
+      bump: 'minor',
+      weight: 1,
+    },
+    {
+      title: '📈 Enhancement',
+      labels: ['enhancement', 'refactor', 'enhancement 👆️'],
+      bump: 'minor',
+    },
+    {
+      title: '🐛 Bug Fixes',
+      labels: ['bug', 'bug 🐛️'],
+      bump: 'patch',
+    },
+    {
+      title: '📚 Documentation',
+      labels: ['docs', 'documentation', 'documentation 📖️'],
+      bump: 'patch',
+    },
+    {
+      title: '📦️ Dependency',
+      labels: ['dependency', 'dependencies'],
+      bump: 'patch',
+      weight: -1,
+    },
+    {
+      title: 'Misc',
+      labels: ['misc', 'chore 🧰'],
+      bump: 'patch',
+      default: true,
+      weight: -2,
     },
   ],
 };

--- a/docs.md
+++ b/docs.md
@@ -62,7 +62,57 @@ Add a `release-config.ts` file to the root of your repository. Have a look at th
 
 ```ts
 export default {
-  commentOnReleasedPullRequests: true,
+  changeTypes: [
+    {
+      title: '💥 Breaking changes',
+      labels: ['breaking'],
+      bump: 'major',
+      weight: 3,
+    },
+    {
+      title: '🔒 Security',
+      labels: ['security'],
+      bump: 'patch',
+      weight: 2,
+    },
+    {
+      title: '✨ Features',
+      labels: ['feature', 'feature 🚀️'],
+      bump: 'minor',
+      weight: 1,
+    },
+    {
+      title: '📈 Enhancement',
+      labels: ['enhancement', 'refactor', 'enhancement 👆️'],
+      bump: 'minor',
+    },
+    {
+      title: '🐛 Bug Fixes',
+      labels: ['bug', 'bug 🐛️'],
+      bump: 'patch',
+    },
+    {
+      title: '📚 Documentation',
+      labels: ['docs', 'documentation', 'documentation 📖️'],
+      bump: 'patch',
+    },
+    {
+      title: '📦️ Dependency',
+      labels: ['dependency', 'dependencies'],
+      bump: 'patch',
+      weight: -1,
+    },
+    {
+      title: 'Misc',
+      labels: ['misc', 'chore 🧰'],
+      bump: 'patch',
+      default: true,
+      weight: -2,
+    },
+  ],
+  skipLabels: ['skip-release', 'skip-changelog', 'regression'],
+  skipCommitsWithoutPullRequest: true,
+  commentOnReleasedPullRequests: false,
 };
 ```
 


### PR DESCRIPTION
Just added the default `changeTypes` config from sources to readme and docs - Should help new users to implement this plugin without the need to look into the sources 😸 