### PR TITLE
Prevent invalid semver version 0.0.x

### DIFF
--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -116,6 +116,11 @@ describe('change', () => {
       const nextVersion = getNextVersionFromLabels('1.0.1-rc.2', config.user, changesWithMinor, true);
       expect(nextVersion).toBe('1.1.0-rc.0');
     });
+
+    it('should get 0.1.0 for first version with only bugfix', () => {
+      const nextVersion = getNextVersionFromLabels('0.0.0', config.user, changesWithPatch, false);
+      expect(nextVersion).toBe('0.1.0');
+    });
   });
 
   describe('changelog generation', () => {

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -13,6 +13,10 @@ export function getNextVersionFromLabels(
     return null;
   }
 
+  if (semver.major(lastVersion) === 0 && semver.minor(lastVersion) === 0) {
+    return semver.inc(lastVersion, 'minor');
+  }
+
   const changeLabels = config.changeTypes!.reduce(
     (acc, c) => {
       acc[c.bump].push(...c.labels);


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/plugin-ready-release-go/issues/278