### PR TITLE
Add 'Merge pull request' to the commit message check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,8 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   await git.branch(['--set-upstream-to', `origin/${releaseBranch}`]);
   await git.pull();
 
-  const isReleaseCommit = config.ci.commitMessage?.startsWith(config.ci.releasePrefix);
+  const isReleaseCommit = config.ci.commitMessage?.startsWith(config.ci.releasePrefix) ||
+    config.ci.commitMessage?.startsWith(`Merge pull request '${config.ci.releasePrefix}`);
 
   const pullRequestBranch = `${config.ci.pullRequestBranchPrefix}${releaseBranch}`;
 


### PR DESCRIPTION
The default merge message on Gitea/Forgejo is like `Merge pull request '🎉 Release 5.0.5...`.

This PR adds support for checking if the message starts with `Merge pull request '` then the release prefix. This fixes #205 