### PR TITLE
Added `includeContributors` option 

### DIFF
--- a/src/cmd/prepare.ts
+++ b/src/cmd/prepare.ts
@@ -68,7 +68,7 @@ export async function prepare(cmdCtx: CommandContext) {
   if (await fs.stat('CHANGELOG.md').catch(() => false)) {
     oldChangelog = await fs.readFile('CHANGELOG.md', 'utf-8');
   }
-  const newChangelogSection = getChangeLogSection(nextVersion, tag, config, changes, forge, true);
+  const newChangelogSection = getChangeLogSection(nextVersion, tag, config, changes, forge, config.user.includeContributors);
   const changelog = updateChangelogSection(latestVersion, nextVersion, oldChangelog, newChangelogSection);
 
   console.log('# Updating CHANGELOG.md');

--- a/src/cmd/release.ts
+++ b/src/cmd/release.ts
@@ -32,7 +32,7 @@ export async function release({
 
   const tag = useVersionPrefixV && !nextVersion.startsWith('v') ? `v${nextVersion}` : nextVersion;
 
-  const newChangelogSection = getChangeLogSection(nextVersion, tag, config, changes, forge, true);
+  const newChangelogSection = getChangeLogSection(nextVersion, tag, config, changes, forge, config.user.includeContributors);
 
   const releaseDescription = config.user.getReleaseDescription
     ? await config.user.getReleaseDescription(hookCtx)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,7 @@ const ciConfig = {
   pullRequestBranchPrefix: process.env.PLUGIN_PULL_REQUEST_BRANCH_PREFIX || 'next-release/',
   debug: process.env.PLUGIN_DEBUG === 'true',
   releasePrefix: process.env.PLUGIN_RELEASE_PREFIX || '🎉 Release',
+  includeContributors: process.env.PLUGIN_INCLUDE_CONTRIBUTORS === 'true',
 };
 
 export type Config = { user: UserConfig; ci: typeof ciConfig };
@@ -73,6 +74,7 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: false,
+  includeContributors: true,
 };
 
 export async function getConfig(basePath?: string): Promise<Config> {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -108,6 +108,12 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
+
+  /**
+   * Include the 'Thanks to all contributors' section with a list of contributors
+   * @default true
+   */
+  includeContributors: boolean;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;


### PR DESCRIPTION
This PR adds an `includeContributors` option for removing the "Thanks to all contributors" message with a list of contributors