### PR TITLE
feat: add config to set release as latest

### DIFF
--- a/src/cmd/release.ts
+++ b/src/cmd/release.ts
@@ -47,6 +47,7 @@ export async function release({
     name: nextVersion,
     prerelease: shouldBeRC,
     target: config.ci.releaseBranch,
+    isLatest: config.user.isLatestRelease,
   });
 
   console.log(c.green('# Successfully created release:'), releaseLink);

--- a/src/cmd/release.ts
+++ b/src/cmd/release.ts
@@ -38,6 +38,8 @@ export async function release({
     ? await config.user.getReleaseDescription(hookCtx)
     : newChangelogSection;
 
+  const isLatest = config.user.useLatestRelease ? await config.user.useLatestRelease(hookCtx) : true;
+
   console.log('# Creating release');
   const { releaseLink } = await forge.createRelease({
     owner: config.ci.repoOwner,
@@ -47,7 +49,7 @@ export async function release({
     name: nextVersion,
     prerelease: shouldBeRC,
     target: config.ci.releaseBranch,
-    isLatest: config.user.isLatestRelease,
+    isLatest,
   });
 
   console.log(c.green('# Successfully created release:'), releaseLink);

--- a/src/forges/forge.ts
+++ b/src/forges/forge.ts
@@ -34,6 +34,7 @@ export abstract class Forge {
     description: string;
     prerelease?: boolean;
     target: string;
+    isLatest?: boolean;
   }): Promise<{
     releaseLink: string;
   }>;

--- a/src/forges/github.ts
+++ b/src/forges/github.ts
@@ -62,6 +62,7 @@ export class GithubForge extends Forge {
     description: string;
     prerelease?: boolean;
     target: string;
+    isLatest?: boolean;
   }): Promise<{ releaseLink: string }> {
     const release = await this.octokit.repos.createRelease({
       owner: options.owner,
@@ -71,6 +72,7 @@ export class GithubForge extends Forge {
       body: options.description,
       prerelease: options.prerelease,
       target_commitish: options.target,
+      make_latest: options.isLatest ? 'true' : 'false',
     });
 
     return { releaseLink: release.data.html_url };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -73,6 +73,7 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: false,
+  isLatestRelease: true,
 };
 
 export async function getConfig(basePath?: string): Promise<Config> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -73,7 +73,6 @@ export const defaultUserConfig: UserConfig = {
   skipLabels: ['skip-release', 'skip-changelog', 'regression'],
   skipCommitsWithoutPullRequest: true,
   commentOnReleasedPullRequests: false,
-  isLatestRelease: true,
 };
 
 export async function getConfig(basePath?: string): Promise<Config> {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -77,6 +77,13 @@ export type UserConfig = Partial<{
    */
   afterRelease: (ctx: HookContext) => PromiseOrValue<boolean | void>;
 
+  /**
+   * Determine if a release should be set as latest. Returns true by default.
+   *
+   * Note: This only has an effect for GitHub releases.
+   */
+  useLatestRelease: (ctx: HookContext) => PromiseOrValue<boolean>;
+
   changeTypes: {
     title: string;
     labels: string[];
@@ -108,13 +115,6 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
-
-  /**
-   * Set the newly created release as latest.
-   * Note: This only has an effect for GitHub releases.
-   * @default true
-   */
-  isLatestRelease: boolean;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -108,6 +108,13 @@ export type UserConfig = Partial<{
    * @default true
    */
   commentOnReleasedPullRequests: boolean;
+
+  /**
+   * Set the newly created release as latest.
+   * Note: This only has an effect for GitHub releases.
+   * @default true
+   */
+  isLatestRelease: boolean;
 }>;
 
 export const defineConfig = (config: UserConfig) => config;


### PR DESCRIPTION
### Description

Adds a user config to declare whether a release should be declared as latest or not. This currently only works for releases on GitHub though.

### Why is this useful

One of the projects I'm working in has LTS for older versions. So there might be scenarios where the latest version is e.g. `5.0.0` but we now need to ship a version `3.2.1`. In this scenario we don't want version `3.2.1` to be set as latest, hence we need a way to configure this.