### PR TITLE
fix: getNextVersion not working

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   const pullRequestBranch = `${config.ci.pullRequestBranchPrefix}${releaseBranch}`;
 
   let shouldBeRC = false;
-  let nextVersion: string | null = config.user.getNextVersion ? await config.user.getNextVersion(hookCtx) : null;
+  let nextVersion: string | null = null;
 
   if (isReleaseCommit) {
     // use commit message for release runs as the pull-request is not available (closed)
@@ -154,7 +154,9 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   }
 
   if (!isReleaseCommit) {
-    nextVersion = getNextVersionFromLabels(latestVersion, config.user, changes, shouldBeRC);
+    nextVersion = config.user.getNextVersion
+      ? await config.user.getNextVersion(hookCtx)
+      : getNextVersionFromLabels(latestVersion, config.user, changes, shouldBeRC);
   }
 
   if (!nextVersion) {


### PR DESCRIPTION
Fixes the `getNextVersion` user config which was being ignored before.

fixes https://github.com/woodpecker-ci/plugin-ready-release-go/issues/335