### PR TITLE
feat: add user config for latest tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   console.log('# Should next version be a release candidate:', c.green(shouldBeRC ? 'yes' : 'no'));
 
   const tags = await git.tags(['--sort=-creatordate']);
-  let latestTag = tags.latest;
+  let latestTag = config.user.getLatestTag ? await config.user.getLatestTag(hookCtx) : tags.latest;
 
   if (tags.all.length > 0) {
     const sortedTags = semver.rsort(tags.all.filter((tag) => semver.valid(tag)));
@@ -99,7 +99,7 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   }
 
   latestTag = latestTag || '0.0.0';
-  if (tags.latest) {
+  if (latestTag) {
     console.log('# Lastest tag is:', c.green(latestTag));
   } else {
     console.log(c.green(`# No tags found. Starting with first tag: ${latestTag}`));

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -84,6 +84,15 @@ export type UserConfig = Partial<{
    */
   useLatestRelease: (ctx: HookContext) => PromiseOrValue<boolean>;
 
+  /**
+   * Get the latest tag.
+   *
+   * Changes from potential newer tags will not be included in the release.
+   * This might be useful when working with backports and stable branches.
+   * Defaults to the latest tag in the repository.
+   */
+  getLatestTag: (ctx: HookContext) => PromiseOrValue<string>;
+
   changeTypes: {
     title: string;
     labels: string[];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -85,10 +85,9 @@ export type UserConfig = Partial<{
   useLatestRelease: (ctx: HookContext) => PromiseOrValue<boolean>;
 
   /**
-   * Get the latest tag.
+   * Get the latest tag for determining unreleased changes relative to the release branch.
    *
-   * Changes from potential newer tags will not be included in the release.
-   * This might be useful when working with backports and stable branches.
+   * This might be useful when working with backports and stable branches to ignore changes from newer tags.
    * Defaults to the latest tag in the repository.
    */
   getLatestTag: (ctx: HookContext) => PromiseOrValue<string>;


### PR DESCRIPTION
Adds a user config for setting the latest tag. This might be useful when working with backports and stable branches. Also see the discussion in https://github.com/woodpecker-ci/plugin-ready-release-go/issues/335 for more details on this.