### PR TITLE
fix: getLatestTag not always being respected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export async function run({ git, forge, config }: { git: SimpleGit; forge: Forge
   const tags = await git.tags(['--sort=-creatordate']);
   let latestTag = config.user.getLatestTag ? await config.user.getLatestTag(hookCtx) : tags.latest;
 
-  if (tags.all.length > 0) {
+  if (tags.all.length > 0 && !config.user.getLatestTag) {
     const sortedTags = semver.rsort(tags.all.filter((tag) => semver.valid(tag)));
     latestTag = sortedTags[0];
   }


### PR DESCRIPTION
Fixes an issue where `getLatestTag` was not being respected if the repository had some pre-existing tags.

Follow-up for https://github.com/woodpecker-ci/plugin-ready-release-go/pull/337, sorry I didn't catch this earlier 🙈 