### PR TITLE
Use explicit .ts extensions for relative

### DIFF
--- a/release-config.ts
+++ b/release-config.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from './src/utils/types';
+import type { UserConfig } from './src/utils/types.ts';
 
 export default {
   skipCommitsWithoutPullRequest: false,

--- a/src/cmd/prepare.ts
+++ b/src/cmd/prepare.ts
@@ -1,7 +1,7 @@
 import c from 'picocolors';
 
-import { CommandContext, HookContext } from '../utils/types';
-import { updateChangelogSection, getChangeLogSection } from '../utils/change';
+import { CommandContext, HookContext } from '../utils/types.ts';
+import { updateChangelogSection, getChangeLogSection } from '../utils/change.ts';
 import { promises as fs } from 'fs';
 
 export async function prepare(cmdCtx: CommandContext) {

--- a/src/cmd/release.ts
+++ b/src/cmd/release.ts
@@ -1,5 +1,5 @@
-import { getChangeLogSection } from '../utils/change';
-import { CommandContext, HookContext } from '../utils/types';
+import { getChangeLogSection } from '../utils/change.ts';
+import { CommandContext, HookContext } from '../utils/types.ts';
 import c from 'picocolors';
 
 export async function release({

--- a/src/forges/gitea.ts
+++ b/src/forges/gitea.ts
@@ -1,4 +1,4 @@
-import { Forge, PullRequest } from './forge';
+import { Forge, PullRequest } from './forge.ts';
 import { giteaApi, Api, PullRequest as GiteaPullRequest } from 'gitea-js';
 
 export class GiteaForge extends Forge {

--- a/src/forges/github.ts
+++ b/src/forges/github.ts
@@ -1,4 +1,4 @@
-import { Forge, PullRequest } from './forge';
+import { Forge, PullRequest } from './forge.ts';
 import { Octokit } from '@octokit/rest';
 
 export class GithubForge extends Forge {

--- a/src/forges/index.ts
+++ b/src/forges/index.ts
@@ -1,7 +1,7 @@
-import { Config } from '../utils/config';
-import { Forge } from './forge';
-import { GithubForge } from './github';
-import { GiteaForge } from './gitea';
+import { Config } from '../utils/config.ts';
+import { Forge } from './forge.ts';
+import { GithubForge } from './github.ts';
+import { GiteaForge } from './gitea.ts';
 
 export async function getForge(config: Config): Promise<Forge> {
   if (!config.ci.gitEmail) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeAll, afterEach, MockedFunction } from 'vitest';
-import { run } from './index';
-import { Config, defaultUserConfig } from './utils/config';
-import { GithubForge } from './forges/github';
+import { run } from './index.ts';
+import { Config, defaultUserConfig } from './utils/config.ts';
+import { GithubForge } from './forges/github.ts';
 import { SimpleGit, simpleGit } from 'simple-git';
-import { release } from './cmd/release';
-import { prepare } from './cmd/prepare';
+import { release } from './cmd/release.ts';
+import { prepare } from './cmd/prepare.ts';
 
 vi.mock('./cmd/prepare');
 vi.mock('./cmd/release');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import c from 'picocolors';
 import type { SimpleGit } from 'simple-git';
 import semver from 'semver';
 
-import { prepare } from './cmd/prepare';
-import { release } from './cmd/release';
-import type { Config } from './utils/config';
-import type { CommandContext, HookContext } from './utils/types';
-import { extractVersionFromCommitMessage, getNextVersionFromLabels } from './utils/change';
-import { getReleaseOptions } from './utils/pr';
-import { Forge } from './forges/forge';
-import { PRLabelAnalyser } from './utils/analyser/pr_labels';
+import { prepare } from './cmd/prepare.ts';
+import { release } from './cmd/release.ts';
+import type { Config } from './utils/config.ts';
+import type { CommandContext, HookContext } from './utils/types.ts';
+import { extractVersionFromCommitMessage, getNextVersionFromLabels } from './utils/change.ts';
+import { getReleaseOptions } from './utils/pr.ts';
+import { Forge } from './forges/forge.ts';
+import { PRLabelAnalyser } from './utils/analyser/pr_labels.ts';
 
 function isReleaseCommit(config: Config): boolean {
   if (!config.ci.commitMessage) return false;

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,7 @@
 import c from 'picocolors';
-import { run } from './index';
-import { getConfig } from './utils/config';
-import { getForge } from './forges';
+import { run } from './index.ts';
+import { getConfig } from './utils/config.ts';
+import { getForge } from './forges/index.ts';
 import simpleGit from 'simple-git';
 
 async function main() {

--- a/src/utils/analyser/pr_labels.ts
+++ b/src/utils/analyser/pr_labels.ts
@@ -1,8 +1,8 @@
 import c from 'picocolors';
 
-import { Forge } from '../../forges/forge';
-import { Config } from '../config';
-import { Analyser, Change, Commit } from '../types';
+import { Forge } from '../../forges/forge.ts';
+import { Config } from '../config.ts';
+import { Analyser, Change, Commit } from '../types.ts';
 
 export class PRLabelAnalyser implements Analyser {
   forge: Forge;

--- a/src/utils/change.test.ts
+++ b/src/utils/change.test.ts
@@ -4,10 +4,10 @@ import {
   getChangeLogSection,
   getNextVersionFromLabels,
   updateChangelogSection,
-} from './change';
-import { Change } from './types';
-import { Config, defaultUserConfig } from './config';
-import { GithubForge } from '../forges/github';
+} from './change.ts';
+import { Change } from './types.ts';
+import { Config, defaultUserConfig } from './config.ts';
+import { GithubForge } from '../forges/github.ts';
 import { promises as fs } from 'fs';
 import path from 'path';
 

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
-import { Change, UserConfig } from './types';
-import { Config } from './config';
-import { Forge } from '../forges/forge';
+import { Change, UserConfig } from './types.ts';
+import { Config } from './config.ts';
+import { Forge } from '../forges/forge.ts';
 
 function incRC(lastVersion: string, bump: 'major' | 'minor' | 'patch'): string | null {
   if (semver.prerelease(lastVersion) === null) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { UserConfig } from './types';
+import { UserConfig } from './types.ts';
 import { promises as fs } from 'fs';
 
 const ciConfig = {

--- a/src/utils/pr.test.ts
+++ b/src/utils/pr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCheckboxValueFromString } from './pr';
+import { getCheckboxValueFromString } from './pr.ts';
 
 describe('pr', () => {
   it('should check for the correct checkbox value', () => {

--- a/src/utils/pr.ts
+++ b/src/utils/pr.ts
@@ -1,4 +1,4 @@
-import { PullRequest } from '../forges/forge';
+import { PullRequest } from '../forges/forge.ts';
 
 export function getCheckboxValueFromString(description: string, label: string) {
   return description.match(new RegExp(`-\\s\\[(.)\\]\\s${label}`, 'i'))?.[1] === 'x';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,6 @@
 import type { ExecFunction } from 'shelljs';
-import type { Forge } from '../forges/forge';
-import type { Config } from './config';
+import type { Forge } from '../forges/forge.ts';
+import type { Config } from './config.ts';
 import type { DefaultLogFields, LogResult, SimpleGit } from 'simple-git';
 
 export type PromiseOrValue<T> = Promise<T> | T;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
Explicit extensions make the module graph resolvable by Deno.

this is a preparation for #186 but works with current node too.